### PR TITLE
Fix remaining compiler warings after 51bbea25 (#63)

### DIFF
--- a/src/lv_demo_printer/lv_demo_printer.c
+++ b/src/lv_demo_printer/lv_demo_printer.c
@@ -362,7 +362,7 @@ LV_EVENT_CB_DECLARE(copy_open_icon_event_cb) {
 
         lv_obj_t * txt = lv_label_create(lv_scr_act(), NULL);
         lv_label_set_text(txt, "Scanning, please wait...");
-        lv_theme_apply(txt, LV_DEMO_PRINTER_THEME_LABEL_WHITE);
+        lv_theme_apply(txt, (lv_theme_style_t)LV_DEMO_PRINTER_THEME_LABEL_WHITE);
         lv_obj_align(txt, arc, LV_ALIGN_OUT_BOTTOM_MID, 0, 60);
 
         lv_demo_printer_anim_in(arc, delay);
@@ -388,7 +388,7 @@ LV_EVENT_CB_DECLARE(scan_open_icon_event_cb)
 
         lv_obj_t * txt = lv_label_create(lv_scr_act(), NULL);
         lv_label_set_text(txt, "Scanning, please wait...");
-        lv_theme_apply(txt, LV_DEMO_PRINTER_THEME_LABEL_WHITE);
+        lv_theme_apply(txt, (lv_theme_style_t)LV_DEMO_PRINTER_THEME_LABEL_WHITE);
         lv_obj_align(txt, arc, LV_ALIGN_OUT_BOTTOM_MID, 0, 60);
 
         lv_demo_printer_anim_in(arc, delay);


### PR DESCRIPTION
In lv_theme_apply, 'name' should be converted into type lv_theme_style_t,
it's already fixed in commit 51bbea25, but 2 more introduced the next day.

Signed-off-by: Xingyou Chen <rockrush@rockwork.org>