### PR TITLE
Fix variable shadowing build error

### DIFF
--- a/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.c
+++ b/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.c
@@ -24,7 +24,7 @@ static void kb_create(void)
 
 }
 
-static void ta_event_cb(lv_obj_t * ta, lv_event_t e)
+static void ta_event_cb(lv_obj_t * ta_local, lv_event_t e)
 {
     if(e == LV_EVENT_CLICKED && kb == NULL) {
         kb_create();


### PR DESCRIPTION
On OSX 10.15.4

```
docker build -t lvgl_simulator .
lv_examples/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.c: In function 'ta_event_cb':
lv_examples/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.c:27:36: error: declaration of 'ta' shadows a global declaration [-Werror=shadow]
 static void ta_event_cb(lv_obj_t * ta, lv_event_t e)
                                    ^~
lv_examples/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.c:5:19: note: shadowed declaration is here
 static lv_obj_t * ta;
                   ^~
cc1: all warnings being treated as errors
Makefile:45: recipe for target 'lv_examples/src/lv_ex_widgets/lv_ex_keyboard/lv_ex_keyboard_1.o' failed
```

The function parameter `ta` is shadowing a static variable at the top of the file with the same name.