### PR TITLE
Add initial CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB_RECURSE SOURCES src/*.c)
+add_library(lv_examples STATIC ${SOURCES})


### PR DESCRIPTION
Added a primitive CMake file to build a library. Actually globbing is not ideal (see here but it can be improved later by swapping with explicit source filenames.

I'm doing this to build the SDL simulator in Windows. I'll detail it on its own PR.