### PR TITLE
build: add cmakelists and integration guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.o
 objs
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.11)
+project(lv_demos)
+
+add_library(lv_demos_ext STATIC)
+
+file(GLOB_RECURSE DEMO_SOURCES "src/*.c")
+
+target_sources(lv_demos_ext PRIVATE ${DEMO_SOURCES})
+
+target_include_directories(lv_demos_ext PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# We assume LVGL is available from the parent project
+target_link_libraries(lv_demos_ext PUBLIC lvgl)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,135 @@
-# Demos for LVGL
+# lv_demos
 
-TODO
+Extended demo applications for LVGL (Light and Versatile Graphics Library). This repository contains niche and specialized demo applications that showcase advanced LVGL features and use cases.
 
+## Overview
+
+This repository contains additional standalone demo applications beyond the core LVGL demos. Each demo is self-contained and demonstrates specific features or real-world applications. Demos can be easily integrated into LVGL-based projects through CMake and FetchContent.
+
+## Repository Structure
+
+```
+lv_demos/
+├── src/
+│   ├── ebike/               # eBike demo
+│   │   ├── *.c              # Demo source files
+│   │   └── *.h              # Demo header files
+│   ├── smartwatch/          # Stress test demo
+│   │   ├── *.c
+│   │   └── *.h
+│   └── lv_demos.h           # Main header with feature guards
+├── CMakeLists.txt           # Build configuration
+├── lv_demos_ext.h           # Public API header
+└── README.md                # This file
+```
+
+## Demo Features
+
+Each demo is conditionally compiled based on `LV_USE_DEMO_*` defines set in `lv_conf.h`. This allows you to include only the demos you need in your project, keeping the binary size minimal.
+
+### Available Demos
+
+Refer to `src/lv_demos.h` for the complete list of available demos and their corresponding `LV_USE_DEMO_*` flags.
+
+## Building
+
+The easiest way to try one of the demos is to add this repository to your application and build the source files by globbing them.
+
+TODO: Document this approach
+
+## CMake
+
+You can also use CMake to integrate these demos into your application
+
+### Prerequisites
+
+- CMake 3.11 or higher
+- C compiler (GCC, Clang, MSVC, etc.)
+- LVGL library (as a dependency)
+
+### Integration with FetchContent
+
+The recommended way to use lv_demos_ext is to add it to your project's main CMakeLists.txt **after** LVGL:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(my_app)
+
+# 1. Add LVGL first via subdirectory or fetchcontent
+add_subdirectory(lvgl)
+
+# 2. Fetch and add lv_demos_ext
+include(FetchContent)
+FetchContent_Declare(
+    lv_demos_ext
+    GIT_REPOSITORY https://github.com/lvgl/lv_demos
+    GIT_TAG master
+)
+FetchContent_MakeAvailable(lv_demos_ext)
+
+# 3. Link lv_demos_ext with LVGL
+target_link_libraries(lvgl PUBLIC lv_demos_ext)
+
+# 4. Link LVGL to your application
+add_executable(my_app src/main.c)
+target_link_libraries(my_app PRIVATE lvgl)
+```
+
+**Important:** LVGL must be added before lv_demos_ext, as lv_demos_ext depends on LVGL being available.
+
+### CMake Integration
+
+For comprehensive CMake integration guidance, refer to the [LVGL CMake documentation](https://docs.lvgl.io/master/details/integration/building/cmake.html).
+
+### Using with lv_port_linux
+
+The [lv_port_linux](https://github.com/lvgl/lv_port_linux) repository can automatically fetch and integrate lv_demos_ext.
+Simply enable one of the demos in your lv_port_linux configuration, and the build system will automatically include lv_demos_ext.
+
+## Usage
+
+Once integrated, enable the desired demos by defining their corresponding `LV_USE_DEMO_*` flags in your `lv_conf.h`:
+
+```c
+#define LV_USE_DEMO_EBIKE 1
+#define LV_USE_DEMO_STRESS 1
+// Add other demo defines as needed
+```
+
+Then include and call the demo in your application:
+
+```c
+#include "lv_demos_ext.h"
+
+int main(void) {
+    lv_init();
+    
+    /* Display a demo */
+    lv_demo_ebike();
+    
+    /* Your event loop */
+    while(1) {
+        uint32_t sleep_ms = lv_timer_handler();
+        lv_sleep_ms(sleep_ms);
+    }
+    
+    return 0;
+}
+```
+
+## Dependencies
+
+- **LVGL**: Light and Versatile Graphics Library - required for all demos
+
+## Contributing
+
+Contributions are welcome! Please submit pull requests with:
+- Clear descriptions of changes
+- Any new demos should follow the existing code structure
+- Proper documentation for new functionality
+
+## Support
+
+For questions regarding LVGL, visit: [LVGL Documentation](https://docs.lvgl.io/)
+
+For issues specific to this repository, please open an issue on Github.

--- a/lv_demo.mk
+++ b/lv_demo.mk
@@ -1,1 +1,2 @@
-CSRCS += $(shell find -L $(LVGL_DIR)/lv_demos -name "*.c")
+LVGL_DEMOS_EXT_DIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+CSRCS += $(shell find -L $(LVGL_DEMOS_EXT_DIR) -name "*.c")

--- a/lv_demos_ext.h
+++ b/lv_demos_ext.h
@@ -36,10 +36,3 @@ extern "C" {
 #endif
 
 #endif /*LV_DEMO_EXT_OUTER_H*/
-
-
-
-
-
-
-

--- a/src/ebike/translations/lv_i18n.h
+++ b/src/ebike/translations/lv_i18n.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "../../lv_demos.h"
+#include "../lv_demo_ebike.h"
 #if LV_USE_DEMO_EBIKE
 
 #include LV_STDINT_INCLUDE

--- a/src/transform/lv_demo_transform.h
+++ b/src/transform/lv_demo_transform.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_demos.h"
+#include "../lv_demos.h"
 
 #if LV_USE_DEMO_TRANSFORM
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds CMake support and integration guides to make lv_demos_ext easy to consume via FetchContent or Makefile. Also cleans up build files and header includes for smoother integration.

- **New Features**
  - Added CMakeLists to build lv_demos_ext as a static library and link with LVGL.
  - Expanded README with FetchContent setup, usage, and lv_port_linux notes.

- **Refactors**
  - Renamed public API header to lv_demos_ext.h and fixed include paths.
  - Updated Makefile to use LVGL_DEMOS_EXT_DIR for source discovery.
  - Ignored build/ in .gitignore.

<!-- End of auto-generated description by cubic. -->

